### PR TITLE
docs(modal): Add missing "mac-" prefix in modal example

### DIFF
--- a/docs/index.jade
+++ b/docs/index.jade
@@ -77,7 +77,7 @@ block append content
       ) Show Modal
     pre.prettyprint.
       &lt;mac-modal id=&quot;test-modal&quot; mac-modal-keyboard&gt;
-        &lt;div ng-controller=&quot;modalController&quot; class=&quot;modal-content&quot;&gt;
+        &lt;div ng-controller=&quot;modalController&quot; class=&quot;mac-modal-content&quot;&gt;
           &lt;h1&gt;Just another modal&lt;/h1&gt;
         &lt;/div&gt;
       &lt;/mac-modal&gt;


### PR DESCRIPTION
While the actual source code correctly uses `class="mac-modal-content"`, the example shown to the user misses prefix `mac-`.
